### PR TITLE
Fix typo images->image in cloudbuild yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,7 +10,7 @@ steps:
   args:
   - run
   - --filename=quokka-engine.yaml
-  - --images=gcr.io/$PROJECT_ID/quokkaqr
+  - --image=gcr.io/$PROJECT_ID/quokkaqr
   - --location=us-west1-a
   - --cluster=quokka-engine
   - --namespace=quokka-qr-prod


### PR DESCRIPTION
CI/CD pipeline Cloud Build failed because of a typo in the yaml. Fixed and updated the yaml file. It should deploy now.