### PR TITLE
Fix location details in cloudbuild yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,6 +11,6 @@ steps:
   - run
   - --filename=quokka-engine.yaml
   - --image=gcr.io/$PROJECT_ID/quokkaqr
-  - --location=us-west1-a
+  - --location=us-west1
   - --cluster=quokka-engine
   - --namespace=quokka-qr-prod


### PR DESCRIPTION
Cloud Build deploy failed because of location config. Looking at the Kubernetes cluster, the location is not specifically us-west1-a but us-west1.