### PR TITLE
Fix cloudbuild yaml with secretmanager config

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,8 @@
 secrets:
-- name: 'SECRET_KEY'
-  version: 'latest'
+- secretManager: 
+    secretId: 'SECRET_KEY'
+    version: 
+     - latest
 steps:
   # Build the custom container image
 - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
Adjusted cloudbuild yaml to properly define secret manager as 'name' is not a valid syntax for it.