### PR TITLE
Use FQRN instead of project name

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,6 @@
 availableSecrets:
  secretManager:
-  - versionName: 'projects/$PROJECT_ID/secrets/quokka_secrets/versions/latest'
+  - versionName: 'projects/876748653486/secrets/quokka-secrets'
 steps:
   # Build the custom container image
 - name: 'gcr.io/cloud-builders/docker'

--- a/qr_gen_flask.py
+++ b/qr_gen_flask.py
@@ -22,7 +22,7 @@ def get_secret_key():
     client = secretmanager.SecretManagerServiceClient()
 
     # Retrieve the secret value
-    project_id = 
+    project_id = '876748653486' 
     secret_name = 'quokka-secrets'
     version_id = 'latest'
     name = f"projects/{project_id}/{secret_name}/versions/{version_id}"


### PR DESCRIPTION
Okay I used the FQRN (Fully Qualified Resource Name), hopefully the cloud build actually triggers. I'm tired of secretEnv not being defined.