### PR TITLE
Use different service account

### DIFF
--- a/quokka-engine.yaml
+++ b/quokka-engine.yaml
@@ -12,7 +12,7 @@ spec:
       labels:
         app: gcp
     spec:
-      serviceAccountName: secret-service-account
+      serviceAccountName: Compute Engine default service account
       containers:
       - name: quokka-qr-gke
         image: gcr.io/quokka-qr-project/quokkaqr:latest


### PR DESCRIPTION
I'm trying different service accounts to deploy alongside my container in the GKE deployment.